### PR TITLE
Multiple updates for usability, error handling, and better data presentation

### DIFF
--- a/callsigns/builder.py
+++ b/callsigns/builder.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from callsigns.fetcher import fetch_and_extract_all
 from callsigns.parser import parse_all_raw
@@ -18,7 +19,15 @@ def build(rootdir: str = '_build') -> None:
     if not os.path.exists(callsign_dir):
         os.mkdir(callsign_dir)
     for callsign, records in call_sign_records.items():
-        fp = os.path.join(callsign_dir, f'{callsign}.json')
+        pattern = r'([A-Z]+)(\d)[A-Z]+'
+        match = re.match(pattern, callsign)
+        if not match:
+            continue
+        call_prefix, region_num = match.groups()
+        callsign_subdir = os.path.join(callsign_dir, region_num, call_prefix)
+        if not os.path.exists(callsign_subdir):
+            os.makedirs(callsign_subdir)
+        fp = os.path.join(callsign_subdir, f'{callsign}.json')
         formatted = [r.as_dict() for r in records]
         with open(fp, 'w') as f:
             json.dump(formatted, f)

--- a/callsigns/constants.py
+++ b/callsigns/constants.py
@@ -240,6 +240,28 @@ FCC_EN_FIELD_NAMES = [
     'Linked Call Sign',
 ]
 
+# REF: https://www.fcc.gov/wireless/data/public-access-files-database-downloads
+#      File: ULS Code Definitions, currently https://www.fcc.gov/sites/default/files/uls_code_definitions_20240215.txt
+
+LICENSE_STATUS_CODES = {
+    'A' : 'Active',
+    'C' : 'Canceled',
+    'E' : 'Expired',
+    'L' : 'Pending Legal Status',
+    'P' : 'Parent Station Canceled',
+    'T' : 'Terminated',
+    'X' : 'Term Pending',
+}
+
+OPERATOR_CLASS_CODES = {
+    'A' : 'Advanced',
+    'E' : 'Amateur Extra',
+    'G' : 'General',
+    'N' : 'Novice',
+    'P' : 'Technician Plus',
+    'T' : 'Technician',
+}
+
 UNAVAILABLE_PATTERNS = [
     # REF: "Call Sign Choices Not Available" http://www.arrl.org/vanity-call-signs
     # 1.KA2AA-KA9ZZ, KC4AAA-KC4AAF, KC4USA-KC4USZ, KG4AA-KG4ZZ, KC6AA-KC6ZZ, KL9KAA- KL9KHZ, KX6AA-KX6ZZ;

--- a/callsigns/parser.py
+++ b/callsigns/parser.py
@@ -13,6 +13,8 @@ from .constants import FCC_HD_FIELD_NAMES
 from .constants import MORSE_TABLE
 from .constants import PHONETIC_WORDS
 from .constants import SYLLABLE_LENGTHS
+from .constants import LICENSE_STATUS_CODES
+from .constants import OPERATOR_CLASS_CODES
 from .fetcher import _get_data_dir_date
 
 
@@ -64,7 +66,7 @@ def to_license_records(raw_records: dict[str, dict[str, dict[str, Any]]]) -> dic
     license_records: dict[str, LicenseRecord] = {}
     for usi, record_data in raw_records.items():
         call_sign = record_data['HD']['Call Sign']
-        status = record_data['HD']['License Status']
+        status = LICENSE_STATUS_CODES[record_data['HD']['License Status']]
         frn = record_data['EN']['FCC Registration Number (FRN)']
         first_name = record_data['EN']['First Name']
         middle_initial = record_data['EN']['MI']
@@ -79,6 +81,8 @@ def to_license_records(raw_records: dict[str, dict[str, dict[str, Any]]]) -> dic
         expired_date = record_data['HD']['Expired Date']
         cancellation_date = record_data['HD']['Cancellation Date']
         operator_class = record_data['AM']['Operator Class'] if 'AM' in record_data else ''
+        if (operator_class is not None) and (operator_class != '') and (operator_class != ' '):
+            operator_class = OPERATOR_CLASS_CODES[operator_class]
         group_code = record_data['AM']['Group Code'] if 'AM' in record_data else ''
         trustee_call_sign = record_data['AM']['Trustee Call Sign'] if 'AM' in record_data else ''
         trustee_name = record_data['AM']['Trustee Name'] if 'AM' in record_data else ''

--- a/callsigns/parser.py
+++ b/callsigns/parser.py
@@ -18,7 +18,7 @@ from .fetcher import _get_data_dir_date
 
 def parse_file(filename: str | pathlib.Path, field_names: list[str]) -> list[dict[str, Any]]:
     with open(filename) as f:
-        reader = csv.DictReader(f, fieldnames=field_names, delimiter='|')
+        reader = csv.DictReader(f, fieldnames=field_names, delimiter='|', quoting=csv.QUOTE_NONE)
         rows = list(reader)
     return rows
 

--- a/callsigns/parser.py
+++ b/callsigns/parser.py
@@ -229,4 +229,6 @@ class LicenseRecord(typing.NamedTuple):
             'format': self.format,
             'phonetic': self.phonetic,
             'syllable_length': self.syllable_length,
+            'fcc_uls_link': self.fcc_uls_link,
+            'qrz_call_sign_link': self.qrz_call_sign_link,
         }


### PR DESCRIPTION
Various updates described below:

- [Update where json files are saved](https://github.com/lovelace/callsign-data/commit/d41b9071b54a6a55377618f361333fd6cc09f072)
> Rather than just dump all the json files we create into a single directory and ensure that navigating the directory is imposible, create a hierarchy of directories that starts with a directory of the region number, then a directory of the callsign prefix before the region number and then place all the json files for that region number and prefix into that directory. This ensures that the files are still easy to find but that we can navigate their directory hierachy easily. So for instance given the callsign K1ABC, the json file will now be in _build/callsigns/1/K/K1ABC.json

- [Turn off quoting in the python csv library](https://github.com/lovelace/callsign-data/commit/15a9b63b72ab7b11cc1d60c9a92a35d2f7e81a1f)
> Recently I found an error in the FCC EN.dat file.  This record:
> 
> EN|3473987|||W2JJW|L|L01773257|West, James "|JAMES|"|WEST|||||602 PROVINCE LINE RD|ALLENTOWN|NJ|08501|||000|0022526404|I||||||
> 
> caused the csv parser to throw all kinds of errors due to the quotes inside the fields. To avoid these errors and because quoting is not used in the FCC dat files anyway, the solution is to simply tell the python csv library to turn quoting off.
> 
> For reference, the quotes in that line used to be the letter J. I'm not sure why they changed.
> 

- [Pretty format license status and operator class codes](https://github.com/lovelace/callsign-data/commit/2f1ddd10cbfdb516691c3beccf8deb102fd178b8)
> Rather than return the single letter codes for license status and operator class, return the full text taken from the FCC ULS Code definitions file.

- [Add FCC ULS and QRZ links for each license record when outputting as a dict.
](https://github.com/lovelace/callsign-data/commit/cdd1cc6b87001b1a0c31ded241d856f7ae21a303)
